### PR TITLE
exit goroutine when closed in conn.receive

### DIFF
--- a/enhttp_test.go
+++ b/enhttp_test.go
@@ -20,6 +20,7 @@ const (
 func TestRoundTrip(t *testing.T) {
 	_, counter, err := fdcount.Matching("TCP")
 	defer func() {
+		time.Sleep(1 * time.Second)
 		assert.NoError(t, counter.AssertDelta(0), "All TCP sockets should have been closed")
 	}()
 

--- a/enhttp_test.go
+++ b/enhttp_test.go
@@ -119,7 +119,7 @@ func TestRoundTrip(t *testing.T) {
 		return
 	}
 	conn.Write([]byte(text))
-	go io.Copy(ioutil.Discard, conn)
+	io.Copy(ioutil.Discard, conn)
 
 	log.Debugf("Echo server is: %v", el.Addr())
 	log.Debugf("enhttp 1 server is: %v", l.Addr())


### PR DESCRIPTION
To avoid piled up goroutines. I noticed it by chance. 
```
goroutine profile: total 691
164 @ 0x4034bfd 0x4034cde 0x400672b 0x4006483 0x4793ec7 0x4066b41
#	0x4793ec6	github.com/getlantern/flashlight/vendor/github.com/getlantern/enhttp.(*conn).receive.func1+0x1e6
github.com/getlantern/flashlight/vendor/github.com/getlantern/enhttp/client.go:140
```